### PR TITLE
Added no-op for FrameworkInstallation when targeting netstandard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Most of the platform information used by the SDK goes to Sentry's [Context Inter
 For details, check the [example project](https://github.com/getsentry/dotnet-sentry-platform-abstractions/tree/426b7b2a002738a5ccbbed644d6ccb3fa26b9eba/samples/Sentry.PlatformAbstractions.Console).
 
 ### Runtime information
-If you are interested in which runtime information, with .NET Standard 1.5 and later you can use `RuntimeInformation.FrameworkDescription`, which will give you a **single string**:
+If you are interested in the runtime information, with .NET Standard 1.5 onwards you can use: `RuntimeInformation.FrameworkDescription`, which will give you a **single string**
 
-For example, .NET Core 2.0.6 on Linux, returns: `.NET Core 4.6.0.0`.
-Not only it doesn't tell you what was installed on the machine but to get the version, you'd need to parse the string.
+For example, .NET Core 2.0.6 on Linux returns: `.NET Core 4.6.0.0`.
+Besides not telling you what was actually installed on the machine, to get the version number you would need to parse the string.
 
-The following table compares results of that API call to what this library returns:
+The following table compares the results of that API call to what this library returns:
 
 |      Target      |       OS         |           RuntimeInformation.FrameworkDescription         |  This library returns an object |
 | ---------------- | ---------------- | --------------------------------------------------------- | ------------------------------- |

--- a/src/Sentry.PlatformAbstractions/FrameworkInfo.NetFx.cs
+++ b/src/Sentry.PlatformAbstractions/FrameworkInfo.NetFx.cs
@@ -1,0 +1,215 @@
+#if NETFX
+using System;
+using System.Collections.Generic;
+using Microsoft.Win32;
+
+namespace Sentry.PlatformAbstractions
+{
+    /// <summary>
+    /// Information about .NET Framework in the running machine
+    /// </summary>
+    public static partial class FrameworkInfo
+    {
+
+        /// <summary>
+        /// Get the latest Framework installation for the specified CLR
+        /// </summary>
+        /// <remarks>
+        /// Supports the current 3 CLR versions:
+        /// CLR 1 => .NET 1.0, 1.1
+        /// CLR 2 => .NET 2.0, 3.0, 3.5
+        /// CLR 4 => .NET 4.0, 4.5.x, 4.6.x, 4.7.x
+        /// </remarks>
+        /// <param name="clrVersion">The CLR version: 1, 2 or 4</param>
+        /// <returns>The framework installation or null if none is found.</returns>
+        public static FrameworkInstallation GetLatest(int clrVersion)
+        {
+            // CLR versions
+            // https://docs.microsoft.com/en-us/dotnet/standard/clr
+            if (clrVersion != 1 && clrVersion != 2 && clrVersion != 4)
+            {
+                return null;
+            }
+
+#if NET45PLUS
+            if (clrVersion == 4)
+            {
+                var release = Get45PlusLatestInstallationFromRegistry();
+                if (release != null)
+                {
+                    return new FrameworkInstallation
+                    {
+                        Version = GetNetFxVersionFromRelease(release.Value),
+                        Release = release
+                    };
+                }
+            }
+#endif
+            FrameworkInstallation latest = null;
+            foreach (var installation in GetInstallations())
+            {
+                if (latest == null)
+                {
+                    latest = installation;
+                }
+
+                if (clrVersion == 2)
+                {
+                    // CLR 2 runs .NET 2 to 3.5
+                    if ((installation.Version.Major == 2 || installation.Version.Major == 3)
+                        && installation.Version >= latest.Version)
+                    {
+                        latest = installation;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                else if (clrVersion == 4)
+                {
+                    if (installation.Version.Major == 4
+                        && installation.Version >= latest.Version)
+                    {
+                        latest = installation;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return latest;
+        }
+
+        /// <summary>
+        /// Get all .NET Framework installations in this machine
+        /// </summary>
+        /// <seealso href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#to-find-net-framework-versions-by-querying-the-registry-in-code-net-framework-1-4"/>
+        /// <returns>Enumeration of installations</returns>
+        public static IEnumerable<FrameworkInstallation> GetInstallations()
+        {
+            using (var ndpKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty)
+                .OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\"))
+            {
+                if (ndpKey == null)
+                {
+                    yield break;
+                }
+
+                foreach (var versionKeyName in ndpKey.GetSubKeyNames())
+                {
+                    if (!versionKeyName.StartsWith("v") || !(ndpKey.OpenSubKey(versionKeyName) is RegistryKey versionKey))
+                    {
+                        continue;
+                    }
+
+                    var version = versionKey.GetString("Version");
+                    if (version != null && versionKey.GetInt("Install") == 1)
+                    {
+                        // 1.0 to 3.5
+                        yield return new FrameworkInstallation
+                        {
+                            ShortName = versionKeyName,
+                            Version = ParseOrNull(version),
+                            ServicePack = versionKey.GetInt("SP")
+                        };
+
+                        continue;
+                    }
+
+                    // 4.0+
+                    foreach (var subKeyName in versionKey.GetSubKeyNames())
+                    {
+                        var subKey = versionKey.OpenSubKey(subKeyName);
+                        if (subKey?.GetInt("Install") != 1)
+                        {
+                            continue;
+                        }
+
+                        yield return GetFromV4(subKey, subKeyName);
+                    }
+                }
+            }
+        }
+
+        private static FrameworkInstallation GetFromV4(RegistryKey subKey, string subKeyName)
+        {
+            var hasRelease = int.TryParse(
+                subKey.GetValue("Release", null)?.ToString(), out var release);
+
+            Version version = null;
+            if (hasRelease)
+            {
+                // 4.5+
+                var displayableVersion = GetNetFxVersionFromRelease(release);
+                if (displayableVersion != null)
+                {
+                    version = displayableVersion;
+                }
+            }
+
+            if (version == null)
+            {
+                version = ParseOrNull(subKey.GetString("Version"));
+            }
+
+            FrameworkProfile? profile = null;
+            switch (subKeyName)
+            {
+                case "Full":
+                    profile = FrameworkProfile.Full;
+                    break;
+                case "Client":
+                    profile = FrameworkProfile.Client;
+                    break;
+            }
+
+            return new FrameworkInstallation
+            {
+                Profile = profile,
+                Version = version,
+                ServicePack = subKey.GetInt("SP"),
+                Release = hasRelease ? release : null as int?
+            };
+        }
+
+#if NET45PLUS
+        // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#to-find-net-framework-versions-by-querying-the-registry-in-code-net-framework-45-and-later
+        internal static int? Get45PlusLatestInstallationFromRegistry()
+        {
+            using (var ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
+                .OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
+            {
+                return ndpKey?.GetInt("Release");
+            }
+        }
+#endif
+
+        internal static Version GetNetFxVersionFromRelease(int release)
+        {
+            NetFxReleaseVersionMap.TryGetValue(release, out var version);
+            return ParseOrNull(version);
+        }
+
+        private static Version ParseOrNull(string version)
+        {
+#if NET35
+            try
+            {
+                return new Version(version);
+            }
+            catch
+            {
+                return null;
+            }
+#else
+            Version.TryParse(version, out var parsed);
+            return parsed;
+#endif
+        }
+    }
+}
+
+#endif

--- a/src/Sentry.PlatformAbstractions/FrameworkInfo.NetStandard.cs
+++ b/src/Sentry.PlatformAbstractions/FrameworkInfo.NetStandard.cs
@@ -1,0 +1,29 @@
+#if !NETFX
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sentry.PlatformAbstractions
+{
+    /// <summary>
+    /// No-op version for netstandard targets
+    /// </summary>
+    public static partial class FrameworkInfo
+    {
+        /// <summary>
+        /// No-op version for netstandard targets
+        /// </summary>
+        /// <param name="clr"></param>
+        /// <returns></returns>
+        public static FrameworkInstallation GetLatest(int clr) => null;
+
+        /// <summary>
+        /// No-op version for netstandard targets
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<FrameworkInstallation> GetInstallations() 
+            => Enumerable.Empty<FrameworkInstallation>();
+    }
+}
+
+#endif

--- a/src/Sentry.PlatformAbstractions/FrameworkInfo.cs
+++ b/src/Sentry.PlatformAbstractions/FrameworkInfo.cs
@@ -1,15 +1,18 @@
-#if NETFX
-using System;
 using System.Collections.Generic;
-using Microsoft.Win32;
 
 namespace Sentry.PlatformAbstractions
 {
     /// <summary>
     /// Information about .NET Framework in the running machine
+    /// The purpose of this partial class is to expose the API to all targets
+    /// For netstandard, the call to methods will be a simple no-op.
     /// </summary>
-    public static class FrameworkInfo
+    public static partial class FrameworkInfo
     {
+        /// <summary>
+        /// The map between release number and version number
+        /// </summary>
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed" />
 #if HAS_READONLY_COLLECTION
         public static IReadOnlyDictionary<int, string> NetFxReleaseVersionMap { get; set; }
 #else
@@ -17,223 +20,22 @@ namespace Sentry.PlatformAbstractions
 #endif
             = new Dictionary<int, string>
             {
-                { 378389, "4.5" },
-                { 378675, "4.5.1" },
-                { 378758, "4.5.1" },
-                { 379893, "4.5.2" },
-                { 393295, "4.6" },
-                { 393297, "4.6" },
-                { 394254, "4.6.1" },
-                { 394271, "4.6.1" },
-                { 394802, "4.6.2" },
-                { 394806, "4.6.2" },
-                { 460798, "4.7" },
-                { 460805, "4.7" },
-                { 461308, "4.7.1" },
-                { 461310, "4.7.1" },
-                { 461808, "4.7.2" },
-                { 461814, "4.7.2" },
+                {378389, "4.5"},
+                {378675, "4.5.1"},
+                {378758, "4.5.1"},
+                {379893, "4.5.2"},
+                {393295, "4.6"},
+                {393297, "4.6"},
+                {394254, "4.6.1"},
+                {394271, "4.6.1"},
+                {394802, "4.6.2"},
+                {394806, "4.6.2"},
+                {460798, "4.7"},
+                {460805, "4.7"},
+                {461308, "4.7.1"},
+                {461310, "4.7.1"},
+                {461808, "4.7.2"},
+                {461814, "4.7.2"},
             };
-
-        /// <summary>
-        /// Get the latest Framework installation for the specified CLR
-        /// </summary>
-        /// <remarks>
-        /// Supports the current 3 CLR versions:
-        /// CLR 1 => .NET 1.0, 1.1
-        /// CLR 2 => .NET 2.0, 3.0, 3.5
-        /// CLR 4 => .NET 4.0, 4.5.x, 4.6.x, 4.7.x
-        /// </remarks>
-        /// <param name="clr">The CLR version: 1, 2 or 4</param>
-        /// <returns>The framework installation or null if none is found.</returns>
-        public static FrameworkInstallation GetLatest(int clr)
-        {
-            if (clr != 1 && clr != 2 && clr != 4)
-            {
-                return null;
-            }
-
-#if NET45PLUS
-            if (clr == 4)
-            {
-                var release = Get45PlusLatestInstallationFromRegistry();
-                if (release != null)
-                {
-                    return new FrameworkInstallation
-                    {
-                        Version = GetNetFxVersionFromRelease(release.Value),
-                        Release = release
-                    };
-                }
-            }
-#endif
-            FrameworkInstallation latest = null;
-            foreach (var installation in GetInstallations())
-            {
-                if (latest == null)
-                {
-                    latest = installation;
-                }
-
-                if (clr == 2)
-                {
-                    // CLR 2 runs .NET 2 to 3.5
-                    if ((installation.Version.Major == 2
-                        || installation.Version.Major == 3)
-                        && installation.Version >= latest.Version)
-                    {
-                        latest = installation;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-                else if (clr == 4)
-                {
-                    if (installation.Version.Major == 4
-                        && installation.Version >= latest.Version)
-                    {
-                        latest = installation;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return latest;
-        }
-
-        /// <summary>
-        /// Get all .NET Framework installations in this machine
-        /// </summary>
-        /// <seealso href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#to-find-net-framework-versions-by-querying-the-registry-in-code-net-framework-1-4"/>
-        /// <returns>Enumeration of installations</returns>
-        public static IEnumerable<FrameworkInstallation> GetInstallations()
-        {
-            using (var ndpKey = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, string.Empty)
-                .OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\"))
-            {
-                if (ndpKey == null)
-                {
-                    yield break;
-                }
-
-                foreach (var versionKeyName in ndpKey.GetSubKeyNames())
-                {
-                    if (!versionKeyName.StartsWith("v")
-                        || !(ndpKey.OpenSubKey(versionKeyName) is RegistryKey versionKey))
-                    {
-                        continue;
-                    }
-
-                    var version = versionKey.GetString("Version");
-                    if (version != null && versionKey.GetInt("Install") == 1)
-                    {
-                        // 1.0 to 3.5
-                        yield return new FrameworkInstallation
-                        {
-                            ShortName = versionKeyName,
-                            Version = ParseOrNull(version),
-                            ServicePack = versionKey.GetInt("SP")
-                        };
-
-                        continue;
-                    }
-
-                    // 4.0+
-                    foreach (var subKeyName in versionKey.GetSubKeyNames())
-                    {
-                        var subKey = versionKey.OpenSubKey(subKeyName);
-                        if (subKey?.GetInt("Install") != 1)
-                        {
-                            continue;
-                        }
-
-                        yield return GetFromV4(subKey, subKeyName);
-                    }
-                }
-            }
-        }
-
-        private static FrameworkInstallation GetFromV4(RegistryKey subKey, string subKeyName)
-        {
-            var hasRelease = int.TryParse(
-                subKey.GetValue("Release", null)?.ToString(), out var release);
-
-            Version version = null;
-            if (hasRelease)
-            {
-                // 4.5+
-                var displayableVersion = GetNetFxVersionFromRelease(release);
-                if (displayableVersion != null)
-                {
-                    version = displayableVersion;
-                }
-            }
-
-            if (version == null)
-            {
-                version = ParseOrNull(subKey.GetString("Version"));
-            }
-
-            FrameworkProfile? profile = null;
-            switch (subKeyName)
-            {
-                case "Full":
-                    profile = FrameworkProfile.Full;
-                    break;
-                case "Client":
-                    profile = FrameworkProfile.Client;
-                    break;
-            }
-
-            return new FrameworkInstallation
-            {
-                Profile = profile,
-                Version = version,
-                ServicePack = subKey.GetInt("SP"),
-                Release = hasRelease ? release : null as int?
-            };
-        }
-
-#if NET45PLUS
-        // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#to-find-net-framework-versions-by-querying-the-registry-in-code-net-framework-45-and-later
-        internal static int? Get45PlusLatestInstallationFromRegistry()
-        {
-            using (var ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
-                .OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
-            {
-                return ndpKey?.GetInt("Release");
-            }
-        }
-#endif
-
-        internal static Version GetNetFxVersionFromRelease(int release)
-        {
-            NetFxReleaseVersionMap.TryGetValue(release, out var version);
-            return ParseOrNull(version);
-        }
-
-        private static Version ParseOrNull(string version)
-        {
-#if NET35
-            try
-            {
-                return new Version(version);
-            }
-            catch
-            {
-                return null;
-            }
-#else
-            Version.TryParse(version, out var parsed);
-            return parsed;
-#endif
-        }
     }
 }
-
-#endif

--- a/src/Sentry.PlatformAbstractions/FrameworkInstallation.cs
+++ b/src/Sentry.PlatformAbstractions/FrameworkInstallation.cs
@@ -1,4 +1,3 @@
-#if NETFX
 using System;
 
 namespace Sentry.PlatformAbstractions
@@ -74,4 +73,3 @@ namespace Sentry.PlatformAbstractions
         Full
     }
 }
-#endif

--- a/src/Sentry.PlatformAbstractions/RuntimeInfo.cs
+++ b/src/Sentry.PlatformAbstractions/RuntimeInfo.cs
@@ -141,7 +141,7 @@ namespace Sentry.PlatformAbstractions
             // Not recommended on NET45+ (which has RuntimeInformation)
             var version = Environment.Version;
 
-            string friendlyVersion = null;
+            string friendlyVersion;
             switch (version.Major)
             {
                 case 1:

--- a/src/Sentry.PlatformAbstractions/Sentry.PlatformAbstractions.csproj
+++ b/src/Sentry.PlatformAbstractions/Sentry.PlatformAbstractions.csproj
@@ -18,14 +18,14 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>NETCOREAPP;HAS_READONLY_COLLECTION;HAS_RUNTIME_INFORMATION;HAS_ENVIRONMENT_VERSION;$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>NETSTANDARD;NETCOREAPP;HAS_READONLY_COLLECTION;HAS_RUNTIME_INFORMATION;HAS_ENVIRONMENT_VERSION;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <DefineConstants>NETCOREAPP;HAS_READONLY_COLLECTION;HAS_RUNTIME_INFORMATION;HAS_TYPE_INFO;$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>NETSTANDARD;NETCOREAPP;HAS_READONLY_COLLECTION;HAS_RUNTIME_INFORMATION;HAS_TYPE_INFO;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">

--- a/test/Sentry.PlatformAbstractions.Tests/FrameworkInfoNetFxTests.cs
+++ b/test/Sentry.PlatformAbstractions.Tests/FrameworkInfoNetFxTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 namespace Sentry.PlatformAbstractions.Tests
 {
-    public class FrameworkInfoTests
+    public class FrameworkInfoNetFxTests
     {
         [SetUp]
         public void TestSetUp()

--- a/test/Sentry.PlatformAbstractions.Tests/FrameworkInfoNetStandardTests.cs
+++ b/test/Sentry.PlatformAbstractions.Tests/FrameworkInfoNetStandardTests.cs
@@ -1,0 +1,23 @@
+#if !NETFX
+using NUnit.Framework;
+
+namespace Sentry.PlatformAbstractions.Tests
+{
+    public class FrameworkInfoNetStandardTests
+    {
+        [Test]
+        public void GetLatest_Returns_Null()
+        {
+            var latest = FrameworkInfo.GetLatest(4);
+            Assert.Null(latest);
+        }
+
+        [Test]
+        public void GetInstallations_Returns_Empty()
+        {
+            var allInstallations = FrameworkInfo.GetInstallations();
+            Assert.IsEmpty(allInstallations);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
closes #8 

- Separated the code into partial classes, being one of them the `no-op` one
- Removed the `NETFX` directive on `FrameworkInfo` and on `FrameworkInstallation` since netstandard libs should be able to see them
- Added unit tests to assert the no-ops
- Small modification on readme.md 